### PR TITLE
Drone pipeline to release @cs3org/cs3apis package to npm registry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,46 @@
+kind: pipeline
+type: docker
+name: version_bump
+
+trigger:
+  branch:
+  - master
+  event:
+    exclude:
+    - pull_request
+    - tag
+    - promote
+    - rollback
+
+steps:
+- name: Update the package version
+  image: plugins/npm
+  commands:
+    - git config --global user.email "bot@cs3community.org"
+    - git config --global user.name "cs3org-bot"
+    - npm version patch
+- name: Push back the new version into the repo
+  image: appleboy/drone-git-push
+  settings:
+    remote_name: origin
+    ssh_key:
+      from_secret: ssh_key
+
+---
+kind: pipeline
+type: docker
+name: publish
+
+trigger:
+  event:
+    include:
+    - tag
+
+steps:
+- name: npm_publish
+  image: plugins/npm
+  settings:
+    username:
+      from_secret: npm_username
+    token:
+      from_secret: npm_token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,28 @@
 {
   "name": "@cs3org/cs3apis",
   "version": "0.0.1",
-  "lockfileVersion": 1
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cs3org/cs3apis",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-protobuf": "^3.13.0"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.13.0.tgz",
+      "integrity": "sha512-ZIf3qfLFayVrPvAjeKKxO5FRF1/NwRxt6Dko+fWEMuHwHbZx8/fcaAao9b0wCM6kr8qeg2te8XTpyuvKuD9aKw=="
+    }
+  },
+  "dependencies": {
+    "google-protobuf": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.13.0.tgz",
+      "integrity": "sha512-ZIf3qfLFayVrPvAjeKKxO5FRF1/NwRxt6Dko+fWEMuHwHbZx8/fcaAao9b0wCM6kr8qeg2te8XTpyuvKuD9aKw=="
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@cs3org/cs3apis",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@cs3org/cs3apis",
+  "version": "0.0.1",
+  "description": "JavaScript bindings for the CS3APIs to connect Storage and Application Providers ",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cs3org/js-cs3apis.git"
+  },
+  "keywords": [
+    "cs3-apis",
+    "iop",
+    "storage",
+    "synchronization"
+  ],
+  "author": "CS3 Organization",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/cs3org/js-cs3apis/issues"
+  },
+  "homepage": "https://github.com/cs3org/js-cs3apis#readme"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@cs3org/cs3apis",
   "version": "0.0.1",
   "description": "JavaScript bindings for the CS3APIs to connect Storage and Application Providers ",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -21,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/cs3org/js-cs3apis/issues"
   },
-  "homepage": "https://github.com/cs3org/js-cs3apis#readme"
+  "homepage": "https://github.com/cs3org/js-cs3apis#readme",
+  "dependencies": {
+    "google-protobuf": "^3.13.0"
+  }
 }


### PR DESCRIPTION
I've used a [scoped package](https://docs.npmjs.com/using-npm/scope.html) name for this, but might be better to switch to plain `cs3apis`. Opinions? cc/ @labkode @alessandro-p 

Closes https://github.com/sciencemesh/sciencemesh/issues/115 (just for JS, no TS module just yet)